### PR TITLE
Object#timeout is deprecated

### DIFF
--- a/lib/net_x/http_unix.rb
+++ b/lib/net_x/http_unix.rb
@@ -32,7 +32,7 @@ class HTTPUnix < Net::HTTP
   # to the use case of using a Unix Domain Socket.
   def connect_unix
     D "opening connection to #{@socket_path}..."
-    s = timeout(@open_timeout) { UNIXSocket.open(@socket_path) }
+    s = Timeout.timeout(@open_timeout) { UNIXSocket.open(@socket_path) }
     D "opened"
     @socket = BufferedIO.new(s)
     @socket.read_timeout = @read_timeout


### PR DESCRIPTION
with `ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin15]`.

The warning says: Object#timeout is deprecated, use Timeout.timeout
instead.
