### PR TITLE
(maint) add networking as CODEOWNERs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Set the networking team as the main owners of the module
+*       @puppetlabs/networking


### PR DESCRIPTION
This gem is a dependency of https://github.com/puppetlabs/cisco-network-puppet-module and therefore is maintained by @puppetlabs/networking